### PR TITLE
Add underscore/check dependencies to package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use(['coffeescript@1.0.5','random@1.0.2','matb33:collection-hooks@0.7.6','momentjs:moment@2.9.0']);
+  api.use(['underscore', 'check', 'coffeescript@1.0.5','random@1.0.2','matb33:collection-hooks@0.7.6','momentjs:moment@2.9.0']);
   // api.versionsFrom('1.0.4');
   api.addFiles(['collectionRevisions.coffee','restoreRevision.coffee']);
 });


### PR DESCRIPTION
First thanks for this great package.
Unfortunately, at first using your package failed for me because the dependencies "underscore" and "check" are not specified in the package.js

After adding them, everything seems to work fine

```
ReferenceError: _ is not defined
   at [object Object].Mongo.Collection.attachCollectionRevisions (packages/todda00:collection-revisions/collectionRevisions.coffee:21:3)
   ...
```

and

```
ReferenceError: Match is not defined
   at [object Object].Mongo.Collection.attachCollectionRevisions (packages/todda00:collection-revisions/collectionRevisions.coffee:39:14)
   ...
```
